### PR TITLE
Add ARS_example tests

### DIFF
--- a/tests/testthat/test-ARS_example.R
+++ b/tests/testthat/test-ARS_example.R
@@ -1,0 +1,15 @@
+test_that("ARS_example lists available files when no path provided", {
+  files <- ARS_example()
+  expect_true(is.character(files))
+  expect_true(length(files) > 0)
+  expect_true("ARS_V1_Common_Safety_Displays.json" %in% files)
+})
+
+test_that("ARS_example returns the full path to a file", {
+  f <- ARS_example("ARS_V1_Common_Safety_Displays.json")
+  expect_true(file.exists(f))
+})
+
+test_that("ARS_example errors when the file does not exist", {
+  expect_error(ARS_example("nonexistent.file"))
+})


### PR DESCRIPTION
## Summary
- add unit tests for `ARS_example` to verify listing, path retrieval and error handling

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` (fails: `bash: command not found: R`)


------
https://chatgpt.com/codex/tasks/task_b_68c299f2ae288329b408c3f05442b163