### PR TITLE
Add tests for ARD_script_example

### DIFF
--- a/tests/testthat/test-ARD_script_example.R
+++ b/tests/testthat/test-ARD_script_example.R
@@ -1,0 +1,15 @@
+test_that("ARD_script_example lists available files when no path provided", {
+  files <- ARD_script_example()
+  expect_true(is.character(files))
+  expect_true(length(files) > 0)
+  expect_true("ARD_Out14-1-1.R" %in% files)
+})
+
+test_that("ARD_script_example returns the full path to a file", {
+  f <- ARD_script_example("ARD_Out14-1-1.R")
+  expect_true(file.exists(f))
+})
+
+test_that("ARD_script_example errors when the file does not exist", {
+  expect_error(ARD_script_example("nonexistent.file"))
+})


### PR DESCRIPTION
## Summary
- add tests ensuring ARD_script_example lists bundled scripts
- verify path resolution and error handling for ARD_script_example

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c2a42f526c8329b86c92144d290c9c