### PR TITLE
Warn on unsupported ARS file types

### DIFF
--- a/R/readARS.R
+++ b/R/readARS.R
@@ -86,6 +86,13 @@ library(readr)
   # Get file extension (case-insensitive)
   file_ext <- tolower(tools::file_ext(ARS_path))
 
+  if (!file_ext %in% c("json", "xlsx")) {
+    cli::cli_warn(
+      "Input ARS file must be JSON or xlsx; {.path {ARS_path}} was received"
+    )
+    return(invisible(NULL))
+  }
+
   # Read in JSON metadata
   if (file_ext == "json") {
     json_from <- jsonlite::fromJSON(ARS_path)

--- a/tests/testthat/test-readARS.R
+++ b/tests/testthat/test-readARS.R
@@ -1,3 +1,15 @@
+test_that("warns when ARS file is not JSON or xlsx", {
+
+  output_dir = tempdir()
+  adam_folder = tempdir()
+  dummy_path = tempfile(fileext = ".txt")
+
+  expect_warning(
+    readARS(dummy_path, output_dir, adam_folder),
+    "Input ARS file must be JSON or xlsx; .+ was received"
+  )
+})
+
 test_that("R Scripts are created for xlsx cards version", {
 
   # path to file containing ARS metadata


### PR DESCRIPTION
## Summary
- warn via CLI when ARS metadata file extension is not JSON or xlsx
- add regression test for invalid ARS file extension

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*


------
https://chatgpt.com/codex/tasks/task_b_68c2a46b3c0083298975d90a3a858804