### PR TITLE
Warn when methods lack template code

### DIFF
--- a/R/readARS.R
+++ b/R/readARS.R
@@ -1365,10 +1365,23 @@ df2_analysisidhere <- df_pop
 
         # Code
         anmetcode <- AnalysisMethodCodeTemplate %>%
-          dplyr::filter(method_id == methodid,
-                        context %in% c("R", "R (siera)", "siera"),
-                        specifiedAs == "Code") %>%
-          dplyr::select(templateCode)
+          dplyr::filter(
+            method_id == methodid,
+            context %in% c("R", "R (siera)", "siera"),
+            specifiedAs == "Code"
+          ) %>%
+          dplyr::pull(templateCode)
+        anmetcode <- anmetcode[1]
+
+        if (length(anmetcode) == 0 || is.na(anmetcode) || anmetcode == "") {
+          warning(
+            sprintf(
+              "No template code found in AnalysisMethodCodeTemplate for method '%s' referenced by analysis '%s'",
+              methodid, Anas_j
+            )
+          )
+          anmetcode <- ""
+        }
 
         # Parameters
         # to be replaced with Source values:

--- a/tests/testthat/test-readARS.R
+++ b/tests/testthat/test-readARS.R
@@ -10,6 +10,33 @@ test_that("warns when ARS file is not JSON or xlsx", {
   )
 })
 
+test_that("warns when AnalysisMethodCodeTemplate lacks code for method", {
+
+  ARS_path <- ARS_example("test_cards.json")
+  ars_json <- jsonlite::read_json(ARS_path, simplifyVector = FALSE)
+
+  ars_json$methods <- lapply(
+    ars_json$methods,
+    function(m) {
+      if (m$id == "Mth_01") {
+        m$codeTemplate$code <- ""
+      }
+      m
+    }
+  )
+
+  tmp_json <- tempfile(fileext = ".json")
+  jsonlite::write_json(ars_json, tmp_json, auto_unbox = TRUE, pretty = TRUE)
+
+  output_dir <- tempdir()
+  adam_folder <- tempdir()
+
+  expect_warning(
+    readARS(tmp_json, output_dir, adam_folder),
+    "No template code found in AnalysisMethodCodeTemplate for method 'Mth_01'"
+  )
+})
+
 test_that("R Scripts are created for xlsx cards version", {
 
   # path to file containing ARS metadata


### PR DESCRIPTION
## Summary
- Warn if a method referenced in Analyses has no code in AnalysisMethodCodeTemplate
- Test that missing method code triggers a warning

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c410d58de483298bd4c4d9873678ac