### PR TITLE
Warn when ARS JSON metadata sections missing

### DIFF
--- a/R/readARS.R
+++ b/R/readARS.R
@@ -74,6 +74,24 @@ library(magrittr)
   if (file_ext == "json") {
     json_from <- jsonlite::fromJSON(ARS_path)
 
+    required_json_sections <- c(
+      "otherListsOfContents",
+      "mainListOfContents",
+      "dataSubsets",
+      "analysisGroupings",
+      "analyses",
+      "methods"
+    )
+
+    missing_sections <- setdiff(required_json_sections, names(json_from))
+
+    if (length(missing_sections) > 0) {
+      cli::cli_warn(
+        "Input ARS file is missing required metadata sections: {paste(missing_sections, collapse = ", ")}"
+      )
+      return(invisible(NULL))
+    }
+
     #otherListsOfContents (LOPO) --V1ized
     otherListsOfContents <- json_from$otherListsOfContents$contentsList$listItems[[1]]  # this is similar to xlsx
     Lopo <- otherListsOfContents |>

--- a/tests/testthat/test-readARS.R
+++ b/tests/testthat/test-readARS.R
@@ -10,6 +10,21 @@ test_that("warns when ARS file is not JSON or xlsx", {
   )
 })
 
+test_that("warns when JSON metadata is missing required sections", {
+
+  output_dir <- tempdir()
+  adam_folder <- tempdir()
+  json_path <- tempfile(fileext = ".json")
+
+  minimal_json <- list(mainListOfContents = list())
+  jsonlite::write_json(minimal_json, json_path, auto_unbox = TRUE)
+
+  expect_warning(
+    readARS(json_path, output_dir, adam_folder),
+    "Input ARS file is missing required metadata sections: otherListsOfContents, dataSubsets, analysisGroupings, analyses, methods"
+  )
+})
+
 test_that("spec_output generates only specified script", {
   ARS_path <- ARS_example("Common_Safety_Displays_cards.xlsx")
   output_dir <- tempdir()


### PR DESCRIPTION
## Summary
- add a CLI warning when ARS JSON metadata lacks required sections and halt processing early
- cover the warning behaviour with a new test

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d2a6db43c08329aac4a5103a3b79cb