### PR TITLE
Apply styler to generated ARD scripts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     jsonlite,
     stringr,
     readxl,
-    cli
+    cli,
+    styler
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/readARS.R
+++ b/R/readARS.R
@@ -509,8 +509,12 @@ readARS <- function(ARS_path,
       )
     )
 
+    script_code <- get(paste0("code_", Output))
+
+    styled_script_code <- styler::style_text(script_code)
+
     writeLines(
-      get(paste0("code_", Output)),
+      styled_script_code,
       paste0(output_path, "/ARD_", Output, ".R")
     )
   } # end of outputs


### PR DESCRIPTION
## Summary
- style each generated ARD script with styler before writing it to disk
- add styler as a package dependency so formatting is always available

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ed0d39ea1c8329a328508f951dca7d