### PR TITLE
Add contextual comments to ARS helper scripts

### DIFF
--- a/R/AnalysisMethods.R
+++ b/R/AnalysisMethods.R
@@ -19,11 +19,14 @@
                                               analysis_id,
                                               output_id,
                                               envir = parent.frame()) {
+  # Retrieve the method attributes that describe this analysis step.
   method <- analysis_methods %>%
     dplyr::filter(id == method_id) %>%
     dplyr::select(name, description, label, id) %>%
     unique()
 
+  # Capture every operation linked to the method so they can be referenced
+  # by the generated code when needed.
   operations <- analysis_methods %>%
     dplyr::filter(id == method_id) %>%
     dplyr::select(operation_id)
@@ -35,6 +38,8 @@
     paste0("operation_", seq_along(operation_values))
   )
 
+  # Assign operations into the parent environment, mirroring how
+  # ARS metadata references them in method templates.
   for (op_name in names(operations_named)) {
     assign(op_name, operations_named[[op_name]], envir = envir)
   }
@@ -52,6 +57,8 @@
     ) %>%
     dplyr::select(templateCode)
 
+  # Parameter substitution is based on ARS metadata entries that can refer
+  # to values calculated earlier in the script.
   anmetparam_s <- analysis_method_code_parameters %>%
     dplyr::filter(
       method_id == methodid,

--- a/R/AnalysisSet.R
+++ b/R/AnalysisSet.R
@@ -11,9 +11,13 @@
     ))
   }
 
+  # Pull the metadata describing the analysis set that applies to
+  # the first analysis for this output.
   temp_AnSet <- analysis_sets |>
     dplyr::filter(id == analysis_set_id)
 
+  # Extract the dataset, variable, comparison operator, and value used to
+  # define the population for this analysis set.
   cond_adam <- temp_AnSet |>
     dplyr::select(condition_dataset) |>
     as.character()
@@ -40,6 +44,8 @@
     as.character()
   anSetName <- anSetName[1]
 
+  # Translate the ARS comparator codes to R operators for evaluation in
+  # the generated script.
   oper <- dplyr::case_when(
     cond_oper == "EQ" ~ "==",
     cond_oper == "NE" ~ "!=",
@@ -62,6 +68,9 @@
 
   ana_adam2 <- Anas_s2$dataset
 
+  # Generate different population code depending on whether the analysis
+  # set is sourced from the same ADaM as the primary analysis or a
+  # companion dataset.
   if (isTRUE(cond_adam == ana_adam2)) {
     template <- "
 # Apply Analysis Set ---

--- a/R/DataSubsets.R
+++ b/R/DataSubsets.R
@@ -6,10 +6,12 @@
     return("")
   }
 
+  # Ensure we always work with defined comparator/value fields.
   comparator <- ifelse(is.null(comparator), "", comparator)
   value_vector <- unlist(value)
 
   if (identical(file_ext, "xlsx")) {
+    # Excel extracts pipe-delimited lists as comma-separated strings.
     value_vector <- gsub("\\|", ",", as.character(value_vector))
   }
 
@@ -42,6 +44,7 @@
     return(paste0(variable, " %in% ", value_string))
   }
 
+  # Map ARS comparator codes to R operators.
   operator <- dplyr::case_when(
     comparator == "EQ" ~ "==",
     comparator == "NE" ~ "!=",
@@ -67,6 +70,7 @@
     !is.null(comparator) && !is.na(comparator) && comparator == "NE" &&
       !is.null(blank_value) && (identical(blank_value, "") || identical(blank_value, "NA") || is.na(blank_value))
   ) {
+    # NE comparisons against blank values become explicit not-missing tests.
     return(paste0("!is.na(", variable, ") & ", variable, "!= ''"))
   }
 
@@ -89,6 +93,7 @@
     filter_expression = NULL
   )
 
+  # Without metadata or a subset identifier, fall back to the default code.
   if (is.null(data_subsets)) {
     return(result)
   }
@@ -104,6 +109,7 @@
     return(result)
   }
 
+  # Store a cleaned display name for informative comments in the generated code.
   subset_name <- subsetrule %>%
     dplyr::select(name) %>%
     unique() %>%
@@ -124,6 +130,7 @@
       file_ext
     )
   } else {
+    # Multi-level subsets require stitching compound expressions across levels.
     maxlev <- max(subsetrule$level)
 
     if (maxlev <= 1) {
@@ -147,6 +154,7 @@
         log_oper <- NA_character_
       }
 
+      # Convert logical operators to their R equivalents for combining filters.
       rlog_oper <- dplyr::case_when(
         log_oper == "AND" ~ "&",
         log_oper == "OR" ~ "|",

--- a/R/loadADaM.R
+++ b/R/loadADaM.R
@@ -1,7 +1,10 @@
 .generate_adam_loading_code <- function(Anas, Analyses, AnalysisSets, DataSubsets, adam_path) {
+  # Identify the analyses referenced for the current output.
   Analyses_IDs <- Analyses %>%
     dplyr::filter(id %in% Anas$listItem_analysisId)
 
+  # Collect every ADaM dataset referenced directly, in an analysis set,
+  # or within data subset metadata.
   unique_datasets <- c(
     Analyses_IDs$dataset,
     AnalysisSets %>%
@@ -19,6 +22,8 @@
     return("\n# Load ADaM -------\n")
   }
 
+  # Build readr::read_csv calls that standardise character NA handling to
+  # avoid downstream joins failing on missing text values.
   lines <- vapply(unique_datasets, function(ad) {
     ad_path <- paste0(adam_path, "/", ad, ".csv")
     paste0(


### PR DESCRIPTION
## Summary
- add inline comments that explain how ARS analysis methods assign metadata
- clarify data subset generation logic with minimal CDISC-focused guidance
- document how ADaM datasets are resolved and read in generated scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f8bdcd7a088329b00af4851198506c