### PR TITLE
Add Pharmaverse badge and link to documentation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -23,6 +23,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/clymbclinical/siera/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/clymbclinical/siera/actions/workflows/R-CMD-check.yaml)
 [![Downloads](https://cranlogs.r-pkg.org/badges/siera)](https://cran.r-project.org/package=siera)
 [![Codecov](https://codecov.io/gh/clymbclinical/siera/branch/main/graph/badge.svg)](https://app.codecov.io/gh/clymbclinical/siera?branch=main)
+[<img src="http://pharmaverse.org/shields/siera.svg">](https://pharmaverse.org)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ status](https://www.r-pkg.org/badges/version/siera)](https://CRAN.R-project.org/
 [![R-CMD-check](https://github.com/clymbclinical/siera/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/clymbclinical/siera/actions/workflows/R-CMD-check.yaml)
 [![Downloads](https://cranlogs.r-pkg.org/badges/siera)](https://cran.r-project.org/package=siera)
 [![Codecov](https://codecov.io/gh/clymbclinical/siera/branch/main/graph/badge.svg)](https://app.codecov.io/gh/clymbclinical/siera?branch=main)
+[<img src="http://pharmaverse.org/shields/siera.svg">](https://pharmaverse.org)
 
 <!-- badges: end -->
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,7 @@
 url: https://clymbclinical.github.io/siera/
 template:
   bootstrap: 5
+home:
+  links:
+  - text: Pharmaverse
+    href: https://pharmaverse.org


### PR DESCRIPTION
## Summary
This PR adds recognition of the siera package as part of the Pharmaverse ecosystem by including a Pharmaverse badge in the README and adding a link to Pharmaverse in the pkgdown documentation site.

## Changes
- Added Pharmaverse badge to README.Rmd and README.md that links to pharmaverse.org
- Updated `_pkgdown.yml` to include a Pharmaverse link in the home page navigation

## Details
These changes help users discover that siera is part of the Pharmaverse community and provide easy navigation to the broader ecosystem of pharma-focused R packages. The badge follows the same pattern as other status badges in the README, and the pkgdown link is added to the home page configuration for easy access from the documentation site.

https://claude.ai/code/session_01XwdAPvAfb1Mr1LKnFYW7RH