### PR TITLE
Fix #137: normalise Windows backslashes in ADaM path to forward slashes

### DIFF
--- a/R/loadADaM.R
+++ b/R/loadADaM.R
@@ -39,7 +39,7 @@
   # Build readr::read_csv calls that standardise character NA handling to
   # avoid downstream joins failing on missing text values.
   lines <- vapply(unique_datasets, function(ad) {
-    ad_path <- paste0(adam_path, "/", ad, ".csv")
+    ad_path <- paste0(gsub("\\\\", "/", adam_path), "/", ad, ".csv")
     paste0(
       ad, " <- readr::read_csv('", ad_path, "',\n",
       "                                      show_col_types = FALSE,\n",

--- a/tests/testthat/test-loadADaM.R
+++ b/tests/testthat/test-loadADaM.R
@@ -81,6 +81,28 @@ test_that("ADaM loading code includes all referenced datasets once", {
   expect_equal(extract_code_lines(code), expected_lines)
 })
 
+test_that("Windows backslash paths are normalised to forward slashes", {
+  Anas <- make_anas(listItem_analysisId = "AN1")
+
+  Analyses <- make_analyses(
+    id = "AN1",
+    dataset = "ADSL",
+    analysisSetId = NA_character_,
+    dataSubsetId = NA_character_
+  )
+
+  AnalysisSets  <- make_analysis_sets(id = character(), condition_dataset = character())
+  DataSubsets   <- make_data_subsets(id = character(), condition_dataset = character())
+
+  code <- get_adam_loading_code(
+    Anas, Analyses, AnalysisSets, DataSubsets,
+    adam_path = "C:\\Users\\mbosman\\data"
+  )
+
+  expect_false(grepl("\\\\", code))             # no backslashes in output
+  expect_true(grepl("C:/Users/mbosman/data/ADSL.csv", code, fixed = TRUE))
+})
+
 test_that("header-only code is returned when no datasets are referenced", {
   Anas <- make_anas(listItem_analysisId = character())
 


### PR DESCRIPTION
gsub('\', '/', adam_path) converts backslash separators before embedding the path in the generated read_csv() call. normalizePath() was avoided as it expands relative paths to absolute, breaking portability.