### PR TITLE
Fix #130 / #124: handle missing or empty dataSubsets in JSON and XLSX

### DIFF
--- a/R/loadADaM.R
+++ b/R/loadADaM.R
@@ -19,14 +19,21 @@
 
   # Collect every ADaM dataset referenced directly, in an analysis set,
   # or within data subset metadata.
+  ds_datasets <- character(0)
+  if (!is.null(DataSubsets) &&
+      nrow(DataSubsets) > 0 &&
+      all(c("id", "condition_dataset") %in% colnames(DataSubsets))) {
+    ds_datasets <- DataSubsets %>%
+      dplyr::filter(id %in% Analyses_IDs$dataSubsetId, !is.na(condition_dataset)) %>%
+      dplyr::pull(condition_dataset)
+  }
+
   unique_datasets <- c(
     Analyses_IDs$dataset,
     AnalysisSets %>%
       dplyr::filter(id %in% Analyses_IDs$analysisSetId) %>%
       dplyr::pull(condition_dataset),
-    DataSubsets %>%
-      dplyr::filter(id %in% Analyses_IDs$dataSubsetId, !is.na(condition_dataset)) %>%
-      dplyr::pull(condition_dataset)
+    ds_datasets
   )
 
   unique_datasets <- unique(unique_datasets)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -40,7 +40,8 @@
 #' @return A tibble with columns `listItem_analysisId` and `listItem_outputId`.
 #' @keywords internal
 .extract_lopa_ids <- function(node_df, output_id) {
-  if (is.null(node_df) || nrow(node_df) == 0L) {
+  n <- nrow(node_df)
+  if (is.null(node_df) || is.null(n) || n == 0L) {
     return(tibble::tibble(
       listItem_analysisId = character(0),
       listItem_outputId   = character(0)
@@ -85,7 +86,6 @@
   required_json_sections <- c(
     "otherListsOfContents",
     "mainListOfContents",
-    "dataSubsets",
     "analysisSets",
     "analysisGroupings",
     "analyses",
@@ -120,65 +120,83 @@
   )
 
   JSON_DataSubsets <- json_from$dataSubsets
-  JSONDSL1 <- tibble::tibble(
-    id = json_from$dataSubsets[["id"]],
-    name = json_from$dataSubsets[["name"]],
-    label = json_from$dataSubsets[["label"]],
-    order = json_from$dataSubsets[["order"]],
-    level = json_from$dataSubsets[["level"]],
-    condition_dataset = json_from[["dataSubsets"]][["condition"]][["dataset"]],
-    condition_variable = json_from[["dataSubsets"]][["condition"]][["variable"]],
-    condition_comparator = json_from[["dataSubsets"]][["condition"]][["comparator"]],
-    condition_value = json_from[["dataSubsets"]][["condition"]][["value"]],
-    compoundExpression_logicalOperator = json_from[["dataSubsets"]][["compoundExpression"]][["logicalOperator"]]
-  )
+  ds_n <- if (is.data.frame(JSON_DataSubsets)) nrow(JSON_DataSubsets) else length(JSON_DataSubsets)
 
-  whereClauses <- JSON_DataSubsets[["compoundExpression"]][["whereClauses"]]
-  JSONDSL2 <- data.frame()
-  JSONDSL3 <- data.frame()
-  for (c in seq_len(nrow(JSON_DataSubsets))) {
-    tmp_DSID <- JSON_DataSubsets[c, "id"]
-    tmp_DSname <- JSON_DataSubsets[c, "name"]
-    tmp_DSlabel <- JSON_DataSubsets[c, "label"]
+  if (is.null(JSON_DataSubsets) || ds_n == 0) {
+    # dataSubsets is optional per ARS; produce a well-typed empty tibble.
+    DataSubsets <- tibble::tibble(
+      id = character(),
+      name = character(),
+      label = character(),
+      level = integer(),
+      order = integer(),
+      condition_dataset = character(),
+      condition_variable = character(),
+      condition_comparator = character(),
+      condition_value = character(),
+      compoundExpression_logicalOperator = character()
+    )
+  } else {
+    JSONDSL1 <- tibble::tibble(
+      id = json_from$dataSubsets[["id"]],
+      name = json_from$dataSubsets[["name"]],
+      label = json_from$dataSubsets[["label"]],
+      order = json_from$dataSubsets[["order"]],
+      level = json_from$dataSubsets[["level"]],
+      condition_dataset = json_from[["dataSubsets"]][["condition"]][["dataset"]],
+      condition_variable = json_from[["dataSubsets"]][["condition"]][["variable"]],
+      condition_comparator = json_from[["dataSubsets"]][["condition"]][["comparator"]],
+      condition_value = json_from[["dataSubsets"]][["condition"]][["value"]],
+      compoundExpression_logicalOperator = json_from[["dataSubsets"]][["compoundExpression"]][["logicalOperator"]]
+    )
 
-    if (!is.null(whereClauses[[c]])) {
-      tmp_DS <- tibble::tibble(
-        level = whereClauses[[c]][["level"]],
-        order = whereClauses[[c]][["order"]],
-        condition_dataset = whereClauses[[c]][["condition"]][["dataset"]],
-        condition_variable = whereClauses[[c]][["condition"]][["variable"]],
-        condition_comparator = whereClauses[[c]][["condition"]][["comparator"]],
-        condition_value = whereClauses[[c]][["condition"]][["value"]],
-        compoundExpression_logicalOperator = whereClauses[[c]]$compoundExpression$logicalOperator,
-        id = tmp_DSID,
-        name = tmp_DSname,
-        label = tmp_DSlabel
-      )
-      JSONDSL2 <- dplyr::bind_rows(JSONDSL2, tmp_DS)
+    whereClauses <- JSON_DataSubsets[["compoundExpression"]][["whereClauses"]]
+    JSONDSL2 <- data.frame()
+    JSONDSL3 <- data.frame()
+    for (c in seq_len(nrow(JSON_DataSubsets))) {
+      tmp_DSID <- JSON_DataSubsets[c, "id"]
+      tmp_DSname <- JSON_DataSubsets[c, "name"]
+      tmp_DSlabel <- JSON_DataSubsets[c, "label"]
 
-      whereClausesL2 <- whereClauses[[c]][["compoundExpression"]][["whereClauses"]]
-      for (d in seq_len(nrow(tmp_DS))) {
-        if (!is.null(whereClausesL2[[d]])) {
-          tmp_DSL2 <- tibble::tibble(
-            level = whereClausesL2[[d]][["level"]],
-            order = whereClausesL2[[d]][["order"]],
-            condition_dataset = whereClausesL2[[d]][["condition"]][["dataset"]],
-            condition_variable = whereClausesL2[[d]][["condition"]][["variable"]],
-            condition_comparator = whereClausesL2[[d]][["condition"]][["comparator"]],
-            condition_value = whereClausesL2[[d]][["condition"]][["value"]],
-            id = tmp_DSID,
-            name = tmp_DSname,
-            label = tmp_DSlabel
-          )
-          JSONDSL3 <- dplyr::bind_rows(JSONDSL3, tmp_DSL2)
+      if (!is.null(whereClauses[[c]])) {
+        tmp_DS <- tibble::tibble(
+          level = whereClauses[[c]][["level"]],
+          order = whereClauses[[c]][["order"]],
+          condition_dataset = whereClauses[[c]][["condition"]][["dataset"]],
+          condition_variable = whereClauses[[c]][["condition"]][["variable"]],
+          condition_comparator = whereClauses[[c]][["condition"]][["comparator"]],
+          condition_value = whereClauses[[c]][["condition"]][["value"]],
+          compoundExpression_logicalOperator = whereClauses[[c]]$compoundExpression$logicalOperator,
+          id = tmp_DSID,
+          name = tmp_DSname,
+          label = tmp_DSlabel
+        )
+        JSONDSL2 <- dplyr::bind_rows(JSONDSL2, tmp_DS)
+
+        whereClausesL2 <- whereClauses[[c]][["compoundExpression"]][["whereClauses"]]
+        for (d in seq_len(nrow(tmp_DS))) {
+          if (!is.null(whereClausesL2[[d]])) {
+            tmp_DSL2 <- tibble::tibble(
+              level = whereClausesL2[[d]][["level"]],
+              order = whereClausesL2[[d]][["order"]],
+              condition_dataset = whereClausesL2[[d]][["condition"]][["dataset"]],
+              condition_variable = whereClausesL2[[d]][["condition"]][["variable"]],
+              condition_comparator = whereClausesL2[[d]][["condition"]][["comparator"]],
+              condition_value = whereClausesL2[[d]][["condition"]][["value"]],
+              id = tmp_DSID,
+              name = tmp_DSname,
+              label = tmp_DSlabel
+            )
+            JSONDSL3 <- dplyr::bind_rows(JSONDSL3, tmp_DSL2)
+          }
         }
       }
     }
-  }
 
-  DataSubsets <- dplyr::bind_rows(JSONDSL1, JSONDSL2, JSONDSL3) |>
-    dplyr::arrange(id, level, order)
-  DataSubsets$condition_value[DataSubsets$condition_value == "NULL"] <- NA
+    DataSubsets <- dplyr::bind_rows(JSONDSL1, JSONDSL2, JSONDSL3) |>
+      dplyr::arrange(id, level, order)
+    DataSubsets$condition_value[DataSubsets$condition_value == "NULL"] <- NA
+  }
 
   AnalysisSets <- tibble::tibble(
     id = json_from$analysisSets$id,
@@ -442,6 +460,21 @@
   mainListOfContents <- readxl::read_excel(ARS_xlsx, sheet = "MainListOfContents")
   otherListsOfContents <- readxl::read_excel(ARS_xlsx, sheet = "OtherListsOfContents")
   DataSubsets <- readxl::read_excel(ARS_xlsx, sheet = "DataSubsets")
+
+  # Ensure DataSubsets has the expected column structure even when the sheet is blank.
+  ds_required_cols <- c(
+    "id", "name", "label", "level", "order",
+    "condition_dataset", "condition_variable",
+    "condition_comparator", "condition_value",
+    "compoundExpression_logicalOperator"
+  )
+  ds_missing_cols <- setdiff(ds_required_cols, colnames(DataSubsets))
+  if (length(ds_missing_cols) > 0) {
+    for (col in ds_missing_cols) {
+      DataSubsets[[col]] <- character(0)
+    }
+  }
+
   AnalysisSets <- readxl::read_excel(ARS_xlsx, sheet = "AnalysisSets")
   AnalysisGroupings <- readxl::read_excel(ARS_xlsx, sheet = "AnalysisGroupings")
   Analyses <- readxl::read_excel(ARS_xlsx, sheet = "Analyses") %>%

--- a/tests/testthat/test-loadADaM.R
+++ b/tests/testthat/test-loadADaM.R
@@ -103,6 +103,50 @@ test_that("Windows backslash paths are normalised to forward slashes", {
   expect_true(grepl("C:/Users/mbosman/data/ADSL.csv", code, fixed = TRUE))
 })
 
+test_that("ADaM loading code handles a completely blank DataSubsets tibble", {
+  Anas <- make_anas(listItem_analysisId = c("AN1"))
+
+  Analyses <- make_analyses(
+    id = c("AN1"),
+    dataset = c("ADSL"),
+    analysisSetId = c("AS1"),
+    dataSubsetId = c(NA_character_)
+  )
+
+  AnalysisSets <- make_analysis_sets(
+    id = c("AS1"),
+    condition_dataset = c("ADSL")
+  )
+
+  # Simulate a completely blank sheet (0 rows, 0 columns)
+  DataSubsets <- tibble::tibble()
+
+  code <- get_adam_loading_code(Anas, Analyses, AnalysisSets, DataSubsets, adam_path = "adam")
+
+  expect_true(grepl("ADSL", code))
+  expect_false(grepl("Error", code))
+})
+
+test_that("ADaM loading code handles NULL DataSubsets", {
+  Anas <- make_anas(listItem_analysisId = c("AN1"))
+
+  Analyses <- make_analyses(
+    id = c("AN1"),
+    dataset = c("ADSL"),
+    analysisSetId = c("AS1"),
+    dataSubsetId = c("DS1")
+  )
+
+  AnalysisSets <- make_analysis_sets(
+    id = c("AS1"),
+    condition_dataset = c("ADSL")
+  )
+
+  code <- get_adam_loading_code(Anas, Analyses, AnalysisSets, NULL, adam_path = "adam")
+
+  expect_true(grepl("ADSL", code))
+})
+
 test_that("header-only code is returned when no datasets are referenced", {
   Anas <- make_anas(listItem_analysisId = character())
 

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -47,6 +47,84 @@ test_that(".read_ars_json_metadata returns the expected tables", {
 })
 
 
+test_that(".read_ars_json_metadata handles empty dataSubsets array", {
+  # dataSubsets is optional; an empty array [] must produce a zero-row tibble.
+  ars_json <- r"[{
+    "name": "Test RE", "id": "TEST_RE",
+    "otherListsOfContents": [{"name": "LOPO", "label": "LOPO",
+      "contentsList": {"listItems": [
+        {"name": "Out1", "level": 1, "order": 1, "outputId": "Out_01"}]}}],
+    "mainListOfContents": {"name": "LOPA", "label": "LOPA",
+      "contentsList": {"listItems": [
+        {"name": "Out1", "level": 1, "order": 1, "outputId": "Out_01",
+         "sublist": {"listItems": [
+           {"name": "An1", "level": 2, "order": 1, "analysisId": "An_01"}]}}]}},
+    "dataSubsets": [],
+    "analysisSets": [{"name": "Safety", "id": "AnalysisSet_01", "level": 1, "order": 1,
+      "condition": {"dataset": "ADSL", "variable": "SAFFL", "comparator": "EQ", "value": ["Y"]}}],
+    "analysisGroupings": [{"name": "Trt", "id": "AG_01",
+      "dataDriven": false, "groupingDataset": "ADSL", "groupingVariable": "TRT01A",
+      "groups": [{"name": "A", "id": "AG_01_1", "level": 1, "order": 1,
+        "condition": {"dataset": "ADSL", "variable": "TRT01A", "comparator": "EQ", "value": ["A"]}}]}],
+    "methods": [{"name": "Count", "label": "Count", "description": "n", "id": "Mth_01",
+      "operations": [{"name": "n", "label": "n", "id": "Mth_01_01_n", "order": 1, "resultPattern": "XX"}],
+      "codeTemplate": {"context": "R (siera)",
+        "code": "df3_analysisidhere <- cards::ard_tabulate(data = df2_analysisidhere, variables = anavarhere)",
+        "parameters": [{"name": "anavarhere", "description": "var", "valueSource": "ana_var"}]}}],
+    "analyses": [{"name": "An1", "id": "An_01", "methodId": "Mth_01", "version": 1,
+      "dataset": "ADSL", "variable": "USUBJID", "analysisSetId": "AnalysisSet_01",
+      "orderedGroupings": [{"order": 1, "groupingId": "AG_01", "resultsByGroup": true}]}]
+  }]"
+
+  ars_file <- withr::local_tempfile(fileext = ".json")
+  writeLines(ars_json, ars_file)
+
+  metadata <- siera:::`.read_ars_json_metadata`(ars_file)
+
+  expect_true("DataSubsets" %in% names(metadata))
+  expect_equal(nrow(metadata$DataSubsets), 0L)
+  expect_true(all(c("id", "condition_dataset", "condition_variable") %in% colnames(metadata$DataSubsets)))
+})
+
+
+test_that(".read_ars_json_metadata handles missing dataSubsets key", {
+  # dataSubsets may be absent; the parser must still return a zero-row tibble.
+  ars_json <- r"[{
+    "name": "Test RE", "id": "TEST_RE",
+    "otherListsOfContents": [{"name": "LOPO", "label": "LOPO",
+      "contentsList": {"listItems": [
+        {"name": "Out1", "level": 1, "order": 1, "outputId": "Out_01"}]}}],
+    "mainListOfContents": {"name": "LOPA", "label": "LOPA",
+      "contentsList": {"listItems": [
+        {"name": "Out1", "level": 1, "order": 1, "outputId": "Out_01",
+         "sublist": {"listItems": [
+           {"name": "An1", "level": 2, "order": 1, "analysisId": "An_01"}]}}]}},
+    "analysisSets": [{"name": "Safety", "id": "AnalysisSet_01", "level": 1, "order": 1,
+      "condition": {"dataset": "ADSL", "variable": "SAFFL", "comparator": "EQ", "value": ["Y"]}}],
+    "analysisGroupings": [{"name": "Trt", "id": "AG_01",
+      "dataDriven": false, "groupingDataset": "ADSL", "groupingVariable": "TRT01A",
+      "groups": [{"name": "A", "id": "AG_01_1", "level": 1, "order": 1,
+        "condition": {"dataset": "ADSL", "variable": "TRT01A", "comparator": "EQ", "value": ["A"]}}]}],
+    "methods": [{"name": "Count", "label": "Count", "description": "n", "id": "Mth_01",
+      "operations": [{"name": "n", "label": "n", "id": "Mth_01_01_n", "order": 1, "resultPattern": "XX"}],
+      "codeTemplate": {"context": "R (siera)",
+        "code": "df3_analysisidhere <- cards::ard_tabulate(data = df2_analysisidhere, variables = anavarhere)",
+        "parameters": [{"name": "anavarhere", "description": "var", "valueSource": "ana_var"}]}}],
+    "analyses": [{"name": "An1", "id": "An_01", "methodId": "Mth_01", "version": 1,
+      "dataset": "ADSL", "variable": "USUBJID", "analysisSetId": "AnalysisSet_01",
+      "orderedGroupings": [{"order": 1, "groupingId": "AG_01", "resultsByGroup": true}]}]
+  }]"
+
+  ars_file <- withr::local_tempfile(fileext = ".json")
+  writeLines(ars_json, ars_file)
+
+  metadata <- siera:::`.read_ars_json_metadata`(ars_file)
+
+  expect_true("DataSubsets" %in% names(metadata))
+  expect_equal(nrow(metadata$DataSubsets), 0L)
+})
+
+
 test_that(".read_ars_metadata dispatches to the XLSX reader", {
   skip_if_not_installed("readxl")
 


### PR DESCRIPTION
## Summary

Closes #130. Supersedes #124 (stale branch, rebased cleanly from current main).

- **R/metadata.R**: Removed dataSubsets from required JSON sections - it is optional per the ARS spec. When json_from\ is NULL or has zero entries, the parser now returns a well-typed empty tibble with all expected columns instead of crashing. For the XLSX path, missing columns in a blank DataSubsets sheet are padded with empty character vectors.
- **R/loadADaM.R**: .generate_adam_loading_code() now guards against NULL or column-less DataSubsets before attempting dplyr::filter().
- **R/metadata.R**: Hardened .extract_lopa_ids() to handle 
row(node_df) returning NULL when jsonlite produces a named list instead of a data frame for a single-item array node.
- **Tests**: Added four new tests covering empty array (JSON), missing key (JSON), blank tibble (loadADaM), and NULL DataSubsets (loadADaM).

## Test plan

- [x] devtools::test_file("tests/testthat/test-metadata.R") - 43 pass, 0 fail
- [x] devtools::test_file("tests/testthat/test-loadADaM.R") - 7 pass, 0 fail
- [x] devtools::check(vignettes = FALSE) - 0 errors, 0 warnings, 1 known NOTE