### PR TITLE
Fix #145: use fixed=TRUE and unique sentinel tokens in gsub() substitution

### DIFF
--- a/R/AnalysisMethods.R
+++ b/R/AnalysisMethods.R
@@ -110,13 +110,14 @@
       anmetcode_temp <- gsub(
         parameter_name,
         rep,
-        anmetcode_temp
+        anmetcode_temp,
+        fixed = TRUE
       )
     }
   }
 
-  anmetcode_final <- gsub("methodidhere", methodid, anmetcode_temp)
-  anmetcode_final <- gsub("analysisidhere", analysis_id, anmetcode_final)
+  anmetcode_final <- gsub("methodidhere", methodid, anmetcode_temp, fixed = TRUE)
+  anmetcode_final <- gsub("analysisidhere", analysis_id, anmetcode_final, fixed = TRUE)
 
   template_intro <- "
 # Method ID:              methodidhere
@@ -124,9 +125,9 @@
 # Method description:     methoddeschere
 "
 
-  code_method_tmp_1 <- gsub("methodidhere", methodid, template_intro)
-  code_method_tmp_1 <- gsub("methodnamehere", methodname, code_method_tmp_1)
-  code_method_tmp_1 <- gsub("methoddeschere", methoddesc, code_method_tmp_1)
+  code_method_tmp_1 <- gsub("methodidhere", methodid, template_intro, fixed = TRUE)
+  code_method_tmp_1 <- gsub("methodnamehere", methodname, code_method_tmp_1, fixed = TRUE)
+  code_method_tmp_1 <- gsub("methoddeschere", methoddesc, code_method_tmp_1, fixed = TRUE)
 
   template <-
     "\nif(nrow(df2_analysisidhere) != 0){\ndf3_analysisidhere <- df3_analysisidhere |>
@@ -136,9 +137,9 @@
                MethodId = 'methodidhere',
                OutputId = 'outputidhere')\n}\n    "
 
-  code <- gsub("methodidhere", methodid, template)
-  code <- gsub("analysisidhere", analysis_id, code)
-  code_method_tmp_3 <- gsub("outputidhere", output_id, code)
+  code <- gsub("methodidhere", methodid, template, fixed = TRUE)
+  code <- gsub("analysisidhere", analysis_id, code, fixed = TRUE)
+  code_method_tmp_3 <- gsub("outputidhere", output_id, code, fixed = TRUE)
 
   code_method <- paste0(
     code_method_tmp_1, "\n",

--- a/R/AnalysisSet.R
+++ b/R/AnalysisSet.R
@@ -150,38 +150,34 @@
   if (isTRUE(cond_adam == ana_adam2)) {
     template <- "
 # Apply Analysis Set ---
-df_pop <- dplyr::filter(ADaM,
-            var operator 'value')
+df_pop <- dplyr::filter(ADaMhere,
+            varhere operatorhere 'valuehere')
 df_poptot <- df_pop
 "
 
-    code <- gsub("ADaM", cond_adam, template)
-    code <- gsub("var", cond_var, code)
-    code <- gsub("operator", oper, code)
-    code <- gsub("value", cond_val, code)
-    code <- gsub("analysisidhere", analysis_id, code)
-    code <- gsub("Analysissetnamehere", anSetName, code)
+    code <- gsub("ADaMhere", cond_adam, template, fixed = TRUE)
+    code <- gsub("varhere", cond_var, code, fixed = TRUE)
+    code <- gsub("operatorhere", oper, code, fixed = TRUE)
+    code <- gsub("valuehere", cond_val, code, fixed = TRUE)
   } else {
     template <- "
 # Apply Analysis Set ---
-overlap <- intersect(names(ADaM), names(analysisADAMhere))
+overlap <- intersect(names(ADaMhere), names(analysisADAMhere))
 overlapfin <- setdiff(overlap, 'USUBJID')
-df_pop <- dplyr::filter(ADaM,
-            var operator 'value') |>
+df_pop <- dplyr::filter(ADaMhere,
+            varhere operatorhere 'valuehere') |>
             merge(analysisADAMhere |> dplyr::select(-dplyr::all_of(overlapfin)),
                   by = 'USUBJID',
                   all = FALSE)
-df_poptot = dplyr::filter(ADaM,
-            var operator 'value')
+df_poptot = dplyr::filter(ADaMhere,
+            varhere operatorhere 'valuehere')
 "
 
-    code <- gsub("ADaM", cond_adam, template)
-    code <- gsub("var", cond_var, code)
-    code <- gsub("operator", oper, code)
-    code <- gsub("value", cond_val, code)
-    code <- gsub("analysisidhere", analysis_id, code)
-    code <- gsub("analysisADAMhere", ana_adam2, code)
-    code <- gsub("Analysissetnamehere", anSetName, code)
+    code <- gsub("ADaMhere", cond_adam, template, fixed = TRUE)
+    code <- gsub("varhere", cond_var, code, fixed = TRUE)
+    code <- gsub("operatorhere", oper, code, fixed = TRUE)
+    code <- gsub("valuehere", cond_val, code, fixed = TRUE)
+    code <- gsub("analysisADAMhere", ana_adam2, code, fixed = TRUE)
   }
 
   list(

--- a/tests/testthat/test-AnalysisMethods.R
+++ b/tests/testthat/test-AnalysisMethods.R
@@ -91,6 +91,53 @@ test_that(".generate_analysis_method_section keeps placeholders when no paramete
   expect_equal(result$operations, list(operation_1 = "OP10"))
 })
 
+test_that("parameter name containing a regex metacharacter is matched literally", {
+  # Without fixed = TRUE, gsub("param.name", ...) treats "." as regex wildcard
+  # and would also replace "paramXname" in addition to "param.name". With
+  # fixed = TRUE only the exact token is replaced.
+  analysis_methods <- tibble(
+    id = "MTH_DOT",
+    name = "Dot test",
+    description = "Test literal matching",
+    label = "dot",
+    operation_id = "OP_DOT"
+  )
+
+  template <- tibble(
+    method_id = "MTH_DOT",
+    context = "R",
+    specifiedAs = "Code",
+    # Contains both the placeholder "param.name" and a similar-looking string
+    # "paramXname" that should NOT be replaced.
+    templateCode = "df3_analysisidhere <- dplyr::filter(df, param.name == 'paramXname')"
+  )
+
+  parameters <- tibble(
+    method_id = "MTH_DOT",
+    parameter_name = "param.name",
+    parameter_valueSource = "operation_1"
+  )
+
+  target_env <- new.env(parent = emptyenv())
+
+  result <- siera:::`.generate_analysis_method_section`(
+    analysis_methods = analysis_methods,
+    analysis_method_code_template = template,
+    analysis_method_code_parameters = parameters,
+    method_id = "MTH_DOT",
+    analysis_id = "AN_DOT",
+    output_id = "OUT_DOT",
+    envir = target_env
+  )
+
+  # The literal placeholder "param.name" must be replaced with the operation ID
+  expect_false(grepl("param.name", result$code, fixed = TRUE))
+  # "paramXname" (which regex "param.name" would also match) must be untouched
+  expect_true(grepl("paramXname", result$code, fixed = TRUE))
+  # The substituted operation ID value must appear
+  expect_true(grepl("OP_DOT", result$code, fixed = TRUE))
+})
+
 test_that(".generate_analysis_method_section warns when no template exists", {
   analysis_methods <- tibble(
     id = "MTH200",

--- a/tests/testthat/test-AnalysisSet.R
+++ b/tests/testthat/test-AnalysisSet.R
@@ -204,6 +204,40 @@ test_that("analysis set code merges companion dataset when needed", {
   expect_equal(result$data_subset, "df_poptot")
 })
 
+test_that("condition value containing regex special characters is preserved verbatim", {
+  # Without fixed = TRUE the replacement string can interact unexpectedly with
+  # regex back-references. A value like "Y(1)" contains "(" which is a regex
+  # metacharacter; with fixed = TRUE it is treated as a literal string.
+  analysis_sets <- make_analysis_sets(
+    id = "AS4",
+    condition_dataset = "ADSL",
+    condition_variable = "TRTGRP",
+    condition_comparator = "EQ",
+    condition_value = "A (High)",
+    name = "TrtGroup"
+  )
+
+  analyses <- make_analyses(
+    id = c("AN1", "AN2"),
+    dataset = c("ADSL", "ADSL")
+  )
+
+  anas <- make_anas(
+    listItem_analysisId = c("AN1", "AN2", "AN1")
+  )
+
+  result <- get_analysis_set_code(
+    j = 1,
+    analysis_sets = analysis_sets,
+    analyses = analyses,
+    anas = anas,
+    analysis_set_id = "AS4",
+    analysis_id = "AN1"
+  )
+
+  expect_true(grepl("A (High)", result$code, fixed = TRUE))
+})
+
 test_that("missing condition values are replaced with empty strings", {
   analysis_sets <- make_analysis_sets(
     id = "AS3",


### PR DESCRIPTION
## Summary

- In `R/AnalysisSet.R`, renamed short placeholder tokens (`ADaM`, `var`, `operator`, `value`) to unique sentinel strings (`ADaMhere`, `varhere`, `operatorhere`, `valuehere`) that cannot appear as substrings of other words in the template. Removed two dead-code `gsub()` calls (`analysisidhere`, `Analysissetnamehere`) whose tokens were absent from both templates.
- Added `fixed = TRUE` to all `gsub()` calls in `AnalysisSet.R` and `AnalysisMethods.R`. Without `fixed = TRUE`, placeholder tokens are treated as regex patterns: short tokens like `var` could match inside longer words if templates are modified, and ARS parameter names containing metacharacters (e.g. `.`) would over-match.
- Added two regression tests: one verifying that a condition value containing `(` is preserved verbatim in generated filter code; one verifying that a parameter name containing `.` (a regex wildcard) replaces only its exact literal token and leaves similar-looking strings untouched.

## Test plan

- [x] `test-AnalysisSet.R` - 14 tests pass, including new regression test
- [x] `test-AnalysisMethods.R` - 20 tests pass, including new regression test
- [x] `devtools::check(vignettes = FALSE)` - 0 errors, 0 warnings, 1 known NOTE