### PR TITLE
.github: add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,140 @@
+name: Bug report
+description: Something in siera errors, warns, or produces the wrong ARD
+labels: ["bug"]
+# assignees:
+#   - <your-github-handle>
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Do not paste patient-level data, sponsor-identifiable study
+        > information, or unpublished study metadata into this issue.**
+        > This repository is public. Reduce ARS metadata and ADaM examples to
+        > the smallest anonymised fragment that shows the problem.
+
+        Title convention: prefix with the component, e.g.
+        `readARS(): ...`, `method library: ...`, `Dataset-JSON export: ...`.
+
+  - type: markdown
+    attributes:
+      value: |
+        A bug in `siera` can sit at three different points: reading the ARS
+        metadata, generating the R script, or running the generated script
+        against the ADaM data. Telling us which one saves a lot of time.
+
+  - type: dropdown
+    id: stage
+    attributes:
+      label: Where does it go wrong?
+      options:
+        - Reading ARS metadata (readARS fails or misreads)
+        - Script generation (script is produced but is wrong)
+        - Running the generated script (errors at runtime)
+        - ARD values are wrong (script runs, numbers are incorrect)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - readARS()
+        - Analysis sets / data subsets
+        - Analysis groupings
+        - Method library / analysis methods
+        - Display formatting / result patterns
+        - Dataset-JSON export
+        - Documentation / vignettes
+        - Packaging, CI, or CRAN checks
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: call
+    attributes:
+      label: The readARS() call
+      render: r
+      placeholder: |
+        library(siera)
+        readARS(
+          ARS_path    = "path/to/ars.json",
+          output_path = "out/",
+          adam_path   = "adam/"
+        )
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ars-format
+    attributes:
+      label: ARS metadata format
+      options:
+        - JSON
+        - xlsx
+    validations:
+      required: true
+
+  - type: textarea
+    id: ars-snippet
+    attributes:
+      label: Minimal ARS fragment
+      description: The smallest piece of ARS metadata that triggers the problem — the analysis, method, or grouping in question. Redact anything sponsor-specific.
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Console output, warning, or generated code
+      description: The error or warning text, and the relevant lines of the generated script if the problem is in the output.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: adam
+    attributes:
+      label: ADaM data used
+      description: e.g. CDISC pilot data, internal study data, or the package's example data.
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: siera version
+      description: Output of `packageVersion("siera")`, or the commit SHA if on the development version.
+      placeholder: "0.5.5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: Installed from
+      options:
+        - CRAN
+        - GitHub (development version)
+        - Internal / validated repository
+    validations:
+      required: true
+
+  - type: textarea
+    id: session-info
+    attributes:
+      label: Session info
+      description: Output of `sessioninfo::session_info()`. Useful when the problem looks environment- or dependency-related.
+      render: r
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.yml
@@ -1,0 +1,79 @@
+name: Enhancement
+description: New capability, wider ARS coverage, or a change in generated-code behaviour
+labels: ["enhancement"]
+# assignees:
+#   - <your-github-handle>
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Do not paste patient-level data, sponsor-identifiable study
+        > information, or unpublished study metadata into this issue.**
+        > This repository is public. Reduce ARS metadata and ADaM examples to
+        > the smallest anonymised fragment that shows the problem.
+
+        Title convention: prefix with the component, e.g.
+        `readARS(): ...`, `method library: ...`, `Dataset-JSON export: ...`.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - readARS() inputs and options
+        - Analysis sets / data subsets
+        - Analysis groupings
+        - Method library / analysis methods
+        - Display formatting / result patterns
+        - Dataset-JSON support
+        - ARS version coverage
+        - Documentation / vignettes
+        - Packaging, CI, or CRAN checks
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What can't be done today?
+      description: The ARS construct, method, or workflow that siera doesn't handle, and what happens instead (silent skip, wrong value, error).
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: What siera should do instead. If it changes the generated script, show the code you'd expect it to emit.
+      render: r
+    validations:
+      required: true
+
+  - type: textarea
+    id: spec
+    attributes:
+      label: Standard reference
+      description: Link to the relevant part of the CDISC ARS model or implementation guide, if this is about conformance.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Does this change output for existing ARS metadata?
+      description: Anything that alters generated scripts or ARD values for inputs that work today needs a NEWS entry and a look at the reverse dependency checks.
+      options:
+        - "No — additive only"
+        - "Yes — generated scripts change"
+        - "Yes — ARD values change"
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Workarounds or related issues
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03_refactor.yml
+++ b/.github/ISSUE_TEMPLATE/03_refactor.yml
@@ -1,0 +1,74 @@
+name: Refactor / tech debt
+description: Internal cleanup with no intended change in behaviour — dead code, duplication, unclear structure
+labels: ["refactor"]
+# assignees:
+#   - <your-github-handle>
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Do not paste patient-level data, sponsor-identifiable study
+        > information, or unpublished study metadata into this issue.**
+        > This repository is public. Reduce ARS metadata and ADaM examples to
+        > the smallest anonymised fragment that shows the problem.
+
+        Title convention: prefix with the component, e.g.
+        `readARS(): ...`, `method library: ...`, `Dataset-JSON export: ...`.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File and function, e.g. `R/readARS.R`, the code_pattern block.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - Dead or unreachable code
+        - Duplication
+        - Unclear or overgrown function
+        - Deprecated path to remove
+        - Performance
+        - Test coverage gap
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: What's there now
+      description: What the code currently does, and how you established it (e.g. never reached for any ARS input, covered by no test).
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+    validations:
+      required: true
+
+  - type: dropdown
+    id: behaviour-change
+    attributes:
+      label: Could this change generated output?
+      description: If yes, it isn't purely a refactor — say what would change and consider an enhancement issue instead.
+      options:
+        - "No — behaviour identical"
+        - "Possibly — needs checking against existing outputs"
+        - "Yes — output changes"
+    validations:
+      required: true
+
+  - type: textarea
+    id: safety-net
+    attributes:
+      label: What proves it's safe?
+      description: Existing tests that cover this path, or tests that would need adding first.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04_documentation.yml
+++ b/.github/ISSUE_TEMPLATE/04_documentation.yml
@@ -1,0 +1,59 @@
+name: Documentation
+description: Docs out of date, an example that needs reworking, or an idea for a new article
+labels: ["documentation"]
+# assignees:
+#   - <your-github-handle>
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Do not paste patient-level data, sponsor-identifiable study
+        > information, or unpublished study metadata into this issue.**
+        > This repository is public.
+
+        Title convention: prefix with `docs:` or the article name.
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: What kind of documentation?
+      multiple: true
+      options:
+        - Function reference (roxygen)
+        - Getting Started vignette
+        - Other vignettes / articles
+        - README
+        - pkgdown site structure or navigation
+        - Developer / contributor guidance
+        - New article idea
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: Page URL, vignette name, or `.R` file the roxygen block sits in.
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's out of date, missing, or unclear?
+      description: Screenshots paste directly into this box.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cause
+    attributes:
+      label: Is this documentation drift or a behaviour question?
+      description: If the docs describe what siera used to do, the code change that caused the drift may also need a NEWS entry.
+      options:
+        - Docs never covered this
+        - Docs describe older behaviour (drift)
+        - Docs are correct but hard to follow
+        - Not sure
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Blank issues stay on: the templates are a scaffold for triage, not a gate.
+# Set to false if you'd rather every issue carry a label from the start.
+blank_issues_enabled: true
+contact_links:
+  - name: Getting started with siera
+    url: https://clymbclinical.github.io/siera/articles/Getting_started.html
+    about: Check the vignette first — usage questions are often answered there.
+  - name: CDISC Analysis Results Standard
+    url: https://www.cdisc.org/standards/foundational/analysis-results-standard
+    about: Questions about the standard itself belong with CDISC, not with siera.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Enhancement
+- [ ] Refactor (no intended change in behaviour)
+- [ ] Documentation only
+- [ ] Packaging / CI
+
+## Effect on generated code
+
+- [ ] No change to generated scripts or ARD values
+- [ ] Generated scripts change (describe below)
+- [ ] ARD values change (describe below)
+
+<!-- If either box above is ticked, say which ARS constructs are affected.
+     Anyone who has validated a reporting event against siera needs to know. -->
+
+## Checklist
+
+Check each box as an acknowledgment that you completed the task.
+
+- [ ] Code follows the [tidyverse style guide](https://style.tidyverse.org/)
+- [ ] Unit tests added or updated for this change
+- [ ] Roxygen headers and examples created or updated
+- [ ] `devtools::document()` run — `man/` and `NAMESPACE` are current
+- [ ] `pkgdown::build_site()` run — examples render and new functions appear on the Reference page
+- [ ] `NEWS.md` updated, if this touches an exported function or user-facing docs
+- [ ] Vignettes updated where affected
+- [ ] `devtools::check()` clean — no ERRORs, WARNINGs, or new NOTEs
+- [ ] Example ARS metadata still generates scripts that run against the ADaM data
+- [ ] Issue linked above so it closes on merge
+- [ ] Merge conflicts resolved
+
+## Notes for reviewers
+
+<!-- Anything you'd like eyes on, or known limitations. -->


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` issue forms and a pull request template, as proposed in #195.

Closes #195

## What's included

- `01_bug_report.yml` (`bug`) - asks where it goes wrong (ARS read / script generation / runtime / wrong values), the `readARS()` call, a minimal ARS fragment, JSON vs xlsx, and version/install source
- `02_enhancement.yml` (`enhancement`) - framed around ARS constructs, with a field for whether existing metadata would start producing different scripts or ARD values
- `03_refactor.yml` (`refactor`) - for cleanup issues in the shape of #191; covers how the path was found to be unreachable and whether output could change
- `04_documentation.yml` (`documentation`) - separates docs that have drifted from docs that are missing
- `config.yml` - contact links to the Getting Started vignette and the CDISC ARS page; blank issues stay enabled so short notes are still easy to file
- `PULL_REQUEST_TEMPLATE.md` - issue link, type of change, and the usual `document()` / `check(vignettes = FALSE)` / tests / `NEWS.md` checklist

Each form carries a short reminder not to paste patient-level or sponsor-identifiable data, since the repo is public.

## Notes for the reviewer

- All four labels the forms apply (`bug`, `enhancement`, `refactor`, `documentation`) already exist in the repo's label set, so nothing needs adding before merging.
- No title prefix is enforced, so the existing `readARS():` / `method library:` convention still applies; it is suggested in the form rather than required.
- Metadata only - no R code, tests, or documentation under `R/`, `man/`, or `vignettes/` is touched, so package behaviour and `R CMD check` are unaffected.
